### PR TITLE
Add flag to prevent duplicate inference and refactor PyTorch hub config

### DIFF
--- a/howl/client/howl_client.py
+++ b/howl/client/howl_client.py
@@ -134,7 +134,7 @@ class HowlClient:
     def from_pretrained(self, name: str, force_reload: bool = False):
         """Load a pretrained model using the provided name"""
         engine, ctx = torch.hub.load(
-            'castorini/howl:howl-pip', name, force_reload=force_reload, reload_models=force_reload)
+            'castorini/howl', name, force_reload=force_reload, reload_models=force_reload)
         self.engine = engine.to(self.device)
         self.ctx = ctx
 

--- a/howl/client/howl_client.py
+++ b/howl/client/howl_client.py
@@ -46,13 +46,13 @@ class HowlClient:
         self._audio_buf = []
         self._audio_buf_len = 16
         self._audio_float_size = 32767
-        self._last_inference_time = time.time()
+        self._infer_detected = False
         self.last_data = np.zeros(self.chunk_size)
 
     @staticmethod
     def list_pretrained(force_reload: bool = False):
         """Show a list of available pretrained models"""
-        print(torch.hub.list('castorini/howl:howl-pip', force_reload=force_reload))
+        print(torch.hub.list('castorini/howl', force_reload=force_reload))
 
     @staticmethod
     def _get_device(device: int):
@@ -75,19 +75,20 @@ class HowlClient:
 
         # Inference from input sequence
         if self.engine.infer(inp):
-            # Check if inference window has passed to prevent callbacks from executing repeatedly
-            cur_time = time.time()
-            time_from_inference_ms = (cur_time - self._last_inference_time) * 1000
-            if time_from_inference_ms < self.engine.max_window_size_ms:
+            # Check if inference has already occured for this sequence to prevent
+            # duplicate callback execution
+            if self._infer_detected:
                 return data_ok
 
-            self._last_inference_time = time.time()
+            self._infer_detected = True
             phrase = ' '.join(self.ctx.vocab[x]
                               for x in self.engine.sequence).title()
             logging.info(f'{phrase} detected')
             # Execute user-provided listener callbacks
             for lis in self.listeners:
                 lis(self.engine.sequence)
+        else:
+            self._infer_detected = False
 
         return data_ok
 

--- a/howl/data/transform/augment.py
+++ b/howl/data/transform/augment.py
@@ -225,7 +225,7 @@ class StandardAudioTransform(AugmentModule):
 
     @torch.no_grad()
     def compute_lengths(self, length: torch.Tensor):
-        return ((length - self.spec_transform.win_length) // self.spec_transform.hop_length + 1).long()
+        return ((length - self.spec_transform.win_length) / self.spec_transform.hop_length + 1).long()
 
 
 class SpecAugmentTransform(AugmentModule):

--- a/howl/model/workspace.py
+++ b/howl/model/workspace.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 import shutil
-from typing import List
+from typing import Any, Dict, List,
 
 from pydantic import BaseSettings
 
@@ -13,15 +13,18 @@ import torch.nn as nn
 from howl.utils.dataclass import gather_dict
 
 
-class WorkspaceSettings(BaseSettings):
+class ModelSettings(BaseSettings):
     model_name: str
     vocab: List[str]
     inference_sequence: List[int]
     token_type: str
     use_frame: bool
-    num_mels: int
-    max_window_size_seconds: int
-    eval_stride_size_seconds: int
+
+
+class WorkspaceSettings(BaseSettings):
+    model: ModelSettings
+    audio_transform: Dict[str, Any] = {}
+    training: Dict[str, Any] = {}
 
 
 @dataclass

--- a/howl/model/workspace.py
+++ b/howl/model/workspace.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 import shutil
-from typing import Any, Dict, List,
+from typing import Any, Dict, List
 
 from pydantic import BaseSettings
 

--- a/howl/settings.py
+++ b/howl/settings.py
@@ -15,6 +15,23 @@ class AudioSettings(BaseSettings):
     use_mono: bool = True
 
 
+class AudioTransformSettings(BaseSettings):
+    num_fft: int = 512
+    num_mels: int = 80
+    sample_rate: int = 16000
+    hop_length: int = 200
+    use_meyda_spectrogram: bool = False
+
+
+class InferenceEngineSettings(BaseSettings):
+    inference_weights: List[float] = None
+    inference_sequence: List[int] = [0]
+    inference_window_ms: float = 2000  # look at last of these seconds
+    smoothing_window_ms: float = 50  # prediction smoothed
+    tolerance_window_ms: float = 500  # negative label between words
+    inference_threshold: float = 0  # positive label probability must rise above this threshold
+
+
 class TrainingSettings(BaseSettings):
     seed: int = 0
     vocab: List[str] = ['fire']
@@ -46,8 +63,11 @@ class DatasetSettings(BaseSettings):
     dataset_path: str = None
 
 
-class LazySettingsSingleton:
+class HowlSettings:
+    """Lazy-loaded class containing all required settings"""
     _audio: AudioSettings = None
+    _audio_transform: AudioTransformSettings = None
+    _inference_engine: InferenceEngineSettings = None
     _raw_dataset: RawDatasetSettings = None
     _dataset: DatasetSettings = None
     _cache: CacheSettings = None
@@ -58,6 +78,18 @@ class LazySettingsSingleton:
         if self._audio is None:
             self._audio = AudioSettings()
         return self._audio
+
+    @property
+    def audio_transform(self) -> AudioTransformSettings:
+        if self._audio_transform is None:
+            self._audio_transform = AudioTransformSettings()
+        return self._audio_transform
+
+    @property
+    def inference_engine(self) -> InferenceEngineSettings:
+        if self._inference_engine is None:
+            self._inference_engine = InferenceEngineSettings()
+        return self._inference_engine
 
     @property
     def raw_dataset(self) -> RawDatasetSettings:
@@ -84,4 +116,14 @@ class LazySettingsSingleton:
         return self._training
 
 
-SETTINGS = LazySettingsSingleton()
+KEY_TO_SETTINGS_CLASS = {
+    '_audio': AudioSettings,
+    '_audio_transform': AudioTransformSettings,
+    '_inference_engine': InferenceEngineSettings,
+    '_raw_dataset': RawDatasetSettings,
+    '_dataset': DatasetSettings,
+    '_cache': CacheSettings,
+    '_training': TrainingSettings,
+}
+
+SETTINGS = HowlSettings()

--- a/howl/utils/dataclass.py
+++ b/howl/utils/dataclass.py
@@ -9,16 +9,18 @@ JSON_PRIMITIVES = {int, float, complex, list, tuple, range, str, bytes, bytearra
 SERIALIZABLE_TYPES = {PosixPath}
 
 
-def gather_dict(dataclass):
+def gather_dict(dataclass, keys_to_ignore = []):
     items = dataclass.dict().items() if isinstance(dataclass, BaseSettings) else dataclass.__dict__.items()
     data_dict = dict()
     for k, v in items:
-        if type(v) in JSON_PRIMITIVES or v is None:
+        if k in keys_to_ignore:
+            continue
+        elif type(v) in JSON_PRIMITIVES or v is None:
             data_dict[k] = v
         elif type(v) in SERIALIZABLE_TYPES:
             data_dict[k] = str(v)
         else:
-            gather_dict(v)
+            data_dict[k] = gather_dict(v)
     return data_dict
 
 

--- a/howl_training/run/generate_precise_dataset.py
+++ b/howl_training/run/generate_precise_dataset.py
@@ -11,7 +11,6 @@ from howl.context import InferenceContext
 from howl.data.dataset import WakeWordDatasetLoader, WakeWordDataset, RecursiveNoiseDatasetLoader, Sha256Splitter,\
     DatasetType
 from howl.data.transform import DatasetMixer
-from howl.model.inference import InferenceEngineSettings
 from howl.settings import SETTINGS
 
 """
@@ -62,7 +61,7 @@ def main():
     loader = WakeWordDatasetLoader()
     ds_kwargs = dict(sr=SETTINGS.audio.sample_rate, mono=SETTINGS.audio.use_mono, frame_labeler=ctx.labeler)
 
-    inference_settings = InferenceEngineSettings()
+    inference_settings = SETTINGS.inference_engine
     wakeword = '_'.join(np.array(SETTINGS.training.vocab)[inference_settings.inference_sequence]).strip()
 
     ww_train_ds, ww_dev_ds, ww_test_ds = WakeWordDataset(metadata_list=[], set_type=DatasetType.TRAINING, **ds_kwargs), \

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,10 +1,10 @@
 """
 Configuration file for loading pretrained models using PyTorch hub
+
 Usage example: torch.hub.load("castorini/howl", "hey_fire_fox")
 """
 dependencies = ['howl', 'torch']
 
-import dataclasses
 import os
 import pathlib
 import shutil
@@ -24,54 +24,44 @@ from howl.settings import SETTINGS as _SETTINGS
 _MODEL_URL = "https://github.com/castorini/howl-models/archive/v1.0.0.zip"
 _MODEL_CACHE_FOLDER = "howl-models"
 
-@dataclasses.dataclass
-class _ModelSettings:
-    path: str # Relative to the howl-models root folder
-    model_name: str
-    vocab: typing.List[str]
-    inference_sequence: typing.List[int]
-    token_type: str
-    use_frame: bool
+
+def hey_fire_fox(pretrained=True, **kwargs):
+    """Pretrained model for Firefox Voice"""
+    engine, ctx = _load_model(pretrained, "howl/hey-fire-fox", **kwargs)
+    return engine, ctx
 
 
-def hey_fire_fox(pretrained=True, **kwargs) \
+def _load_model(pretrained: bool, workspace_path: str, **kwargs) \
         -> typing.Tuple[inference.InferenceEngine, context.InferenceContext]:
-    """
-    Pretrained model for Firefox Voice
-    """
-    # Audio inference settings
-    conf = _ModelSettings(path="howl/hey-fire-fox",
-                          model_name="res8",
-                          vocab=["hey", "fire", "fox"],
-                          inference_sequence=[0, 1, 2],
-                          token_type="word",
-                          use_frame=True)
-    ats = transform.augment.AudioTransformSettings(num_mels=40)
-    _SETTINGS._training = settings.TrainingSettings(max_window_size_seconds=0.5, eval_stride_size_seconds=0.15)
-
     # Separate `reload_models` flag since PyTorch will pop the 'force_reload' flag
     reload_models = kwargs.pop('reload_models', False)
-    cached_folder =_download_howl_models(reload_models)
+    ws = _load_howl_workspace(reload_models, workspace_path)
 
-    # Load workspace from path
-    ws_path: pathlib.Path = pathlib.Path(cached_folder) / conf.path
-    ws = howl_model.Workspace(ws_path, delete_existing=False)
+    # Load model settings
+    ws_settings = ws.load_settings()
+    model_settings = ws_settings.model
+    audio_transform_settings = transform.augment.AudioTransformSettings(**ws_settings.audio_transform)
+    _SETTINGS._training = settings.TrainingSettings(**ws_settings.training)
 
     # Set up context
-    ctx = context.InferenceContext(
-        conf.vocab, token_type=conf.token_type, use_blank=not conf.use_frame)
+    ctx = context.InferenceContext(model_settings.vocab,
+                                   token_type=model_settings.token_type,
+                                   use_blank=not model_settings.use_frame)
 
     # Load models
     zmuv_transform = transform.ZmuvTransform()
     model = howl_model.RegisteredModel.find_registered_class(
-        conf.model_name)(ctx.num_labels).eval()
+        model_settings.model_name)(ctx.num_labels).eval()
+
+    # Load pretrained weights
     if pretrained:
         zmuv_transform.load_state_dict(
-            torch.load(str(ws_path / 'zmuv.pt.bin')))
+            torch.load(str(ws.path / 'zmuv.pt.bin')))
         ws.load_model(model, best=True)
 
+    # Load engine
     model.streaming()
-    if conf.use_frame:
+    if model_settings.use_frame:
         engine = inference.FrameInferenceEngine(int(_SETTINGS.training.max_window_size_seconds * 1000),
                                                 int(_SETTINGS.training.eval_stride_size_seconds * 1000),
                                                 _SETTINGS.audio.sample_rate,
@@ -79,23 +69,27 @@ def hey_fire_fox(pretrained=True, **kwargs) \
                                                 zmuv_transform,
                                                 negative_label=ctx.negative_label,
                                                 coloring=ctx.coloring,
-                                                audio_transform_settings=ats)
+                                                audio_transform_settings=audio_transform_settings)
     else:
         engine = inference.FrameInferenceEngine(_SETTINGS.audio.sample_rate,
                                                 model,
                                                 zmuv_transform,
                                                 negative_label=ctx.negative_label,
                                                 coloring=ctx.coloring,
-                                                audio_transform_settings=ats)
-    engine.sequence = conf.inference_sequence
+                                                audio_transform_settings=audio_transform_settings)
+    engine.sequence = model_settings.inference_sequence
     return engine, ctx
 
 
-def _download_howl_models(reload_models: bool) -> str:
+def _load_howl_workspace(reload_models: bool, workspace_path: str) -> howl_model.Workspace:
     """
     Download Howl models from Github release: https://github.com/castorini/howl-models
-    
-    Returns the cached folder location
+
+    Arguments:
+        reload_models (bool): force reload if models are already cached
+        workspace_path (str): relative path to workspace from root of howl-models
+
+    Returns the specified howl workspace
     """
 
     # Create base cache directory
@@ -106,27 +100,27 @@ def _download_howl_models(reload_models: bool) -> str:
 
     # Check if existing cache should be used
     use_cache = (not reload_models) and os.path.exists(cached_folder)
-    if use_cache:
-        return cached_folder
+    if not use_cache:
+        # Clear cache
+        zip_path = os.path.join(base_dir, _MODEL_CACHE_FOLDER + '.zip')
+        _remove_files(cached_folder)
+        _remove_files(zip_path)
+        torch.hub.download_url_to_file(_MODEL_URL, zip_path, progress=False)
 
-    # Clear cache
-    zip_path = os.path.join(base_dir, _MODEL_CACHE_FOLDER + '.zip')
-    _remove_files(cached_folder)
-    _remove_files(zip_path)
-    torch.hub.download_url_to_file(_MODEL_URL, zip_path, progress=False)
+        # Extract files into folder
+        with zipfile.ZipFile(zip_path) as model_zipfile:
+            # Find name of extracted folder
+            extracted_name = model_zipfile.infolist()[0].filename
+            extracted_path = os.path.join(base_dir, extracted_name)
+            _remove_files(extracted_path)
+            model_zipfile.extractall(base_dir)
 
-    # Extract files into folder
-    with zipfile.ZipFile(zip_path) as model_zipfile:
-        # Find name of extracted folder
-        extracted_name = model_zipfile.infolist()[0].filename
-        extracted_path = os.path.join(base_dir, extracted_name)
-        _remove_files(extracted_path)
-        model_zipfile.extractall(base_dir)
+            # Rename folder
+            shutil.move(extracted_path, cached_folder)
 
-        # Rename folder
-        shutil.move(extracted_path, cached_folder)
+    workspace_path = pathlib.Path(cached_folder) / workspace_path
+    return howl_model.Workspace(workspace_path, delete_existing=False)
 
-    return cached_folder
 
 def _remove_files(path):
     # Remove file or folder if it exists

--- a/hubconf.py
+++ b/hubconf.py
@@ -33,9 +33,21 @@ def hey_fire_fox(pretrained=True, **kwargs):
 
 def _load_model(pretrained: bool, workspace_path: str, **kwargs) \
         -> typing.Tuple[inference.InferenceEngine, context.InferenceContext]:
+    """
+    Loads howl model from a workspace
+
+    Arguments:
+        pretrained (bool): load pretrained model weights
+        workspace_path (str): relative path to workspace from root of howl-models
+
+    Returns the inference engine and context
+    """
+
     # Separate `reload_models` flag since PyTorch will pop the 'force_reload' flag
     reload_models = kwargs.pop('reload_models', False)
-    ws = _load_howl_workspace(reload_models, workspace_path)
+    cached_folder = _download_howl_models(reload_models)
+    workspace_path = pathlib.Path(cached_folder) / workspace_path
+    ws = howl_model.Workspace(workspace_path, delete_existing=False)
 
     # Load model settings
     ws_settings = ws.load_settings()
@@ -81,15 +93,14 @@ def _load_model(pretrained: bool, workspace_path: str, **kwargs) \
     return engine, ctx
 
 
-def _load_howl_workspace(reload_models: bool, workspace_path: str) -> howl_model.Workspace:
+def _download_howl_models(reload_models: bool) -> str:
     """
     Download Howl models from Github release: https://github.com/castorini/howl-models
 
     Arguments:
         reload_models (bool): force reload if models are already cached
-        workspace_path (str): relative path to workspace from root of howl-models
 
-    Returns the specified howl workspace
+    Returns the cached howl models path
     """
 
     # Create base cache directory
@@ -118,8 +129,7 @@ def _load_howl_workspace(reload_models: bool, workspace_path: str) -> howl_model
             # Rename folder
             shutil.move(extracted_path, cached_folder)
 
-    workspace_path = pathlib.Path(cached_folder) / workspace_path
-    return howl_model.Workspace(workspace_path, delete_existing=False)
+    return cached_folder
 
 
 def _remove_files(path):

--- a/hubconf.py
+++ b/hubconf.py
@@ -18,7 +18,7 @@ import howl.data.transform as transform
 import howl.model as howl_model
 import howl.model.inference as inference
 
-_MODEL_URL = "https://github.com/castorini/howl-models/archive/v1.0.0.zip"
+_MODEL_URL = "https://github.com/castorini/howl-models/archive/v1.1.0.zip"
 _MODEL_CACHE_FOLDER = "howl-models"
 
 
@@ -109,7 +109,9 @@ def _download_howl_models(reload_models: bool) -> str:
         zip_path = os.path.join(base_dir, _MODEL_CACHE_FOLDER + '.zip')
         _remove_files(cached_folder)
         _remove_files(zip_path)
-        torch.hub.download_url_to_file(_MODEL_URL, zip_path, progress=False)
+
+        print("Downloading howl-models...")
+        torch.hub.download_url_to_file(_MODEL_URL, zip_path, progress=True)
 
         # Extract files into folder
         with zipfile.ZipFile(zip_path) as model_zipfile:


### PR DESCRIPTION
* For the inference client, I refactored it to avoid duplicate detection using a flag.
* For `hubconf.py` I refactored it so that all of the model loading logic is offloaded to helper functions

Now the steps to add a new pretrained model are:

1. Upload the model weights + settings to the `howl-models` repo and create a new release
2. Add a short function to load the model in `hubconf.py` similar to the one for `hey_fire_fox`
```
def hey_fire_fox(pretrained=True, **kwargs):
    """Pretrained model for Firefox Voice"""
    engine, ctx = _load_model(pretrained, "res8", "howl/hey-fire-fox", **kwargs)
    return engine, ctx
```