### PR TITLE
add (pass through) cpu as a device

### DIFF
--- a/howl/client/howl_client.py
+++ b/howl/client/howl_client.py
@@ -134,7 +134,7 @@ class HowlClient:
     def from_pretrained(self, name: str, force_reload: bool = False):
         """Load a pretrained model using the provided name"""
         engine, ctx = torch.hub.load(
-            'castorini/howl', name, force_reload=force_reload, reload_models=force_reload)
+            'castorini/howl', name, force_reload=force_reload, reload_models=force_reload, device=self.device)
         self.engine = engine.to(self.device)
         self.ctx = ctx
 

--- a/hubconf.py
+++ b/hubconf.py
@@ -34,7 +34,7 @@ def hey_fire_fox(pretrained=True, **kwargs):
 
 
 def _load_model(
-    pretrained: bool, model_name: str, workspace_path: str, **kwargs
+    pretrained: bool, model_name: str, workspace_path: str, device: str, **kwargs
 ) -> typing.Tuple[InferenceEngine, InferenceContext]:
     """
     Loads howl model from a workspace
@@ -66,7 +66,7 @@ def _load_model(
 
     # Load pretrained weights
     if pretrained:
-        zmuv_transform.load_state_dict(torch.load(str(ws.path / "zmuv.pt.bin")))
+        zmuv_transform.load_state_dict(torch.load(str(ws.path / "zmuv.pt.bin"), map_location=torch.device(device)))
         ws.load_model(model, best=True)
 
     # Load engine


### PR DESCRIPTION
updated _load_model in hubconf.py and torch.hub.load (in from_pretrained) in howl_client.py to add (pass through) cpu as a device type