### PR TITLE
Using a single logger across the system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /exp_results
 /montreal-forced-aligner
 
+.bashrc_howl
+
 .vscode/
 .idea/
 

--- a/generate_dataset.sh
+++ b/generate_dataset.sh
@@ -39,7 +39,7 @@ fi
 
 printf "\n\n>>> generating raw audio dataset\n"
 mkdir -p "${DATASET_FOLDER}"
-time VOCAB=${VOCAB} INFERENCE_SEQUENCE=${INFERENCE_SEQUENCE} python -m training.run.generate_raw_audio_dataset -i ${COMMON_VOICE_DATASET_PATH} --positive-pct 100 --negative-pct ${NEGATIVE_PCT}
+time VOCAB=${VOCAB} INFERENCE_SEQUENCE=${INFERENCE_SEQUENCE} python -m training.run.generate_raw_audio_dataset -i ${COMMON_VOICE_DATASET_PATH} --positive-pct 100 --negative-pct ${NEGATIVE_PCT} --overwrite true
 
 NEG_DATASET_PATH="${DATASET_FOLDER}/${DATASET_NAME}/negative"
 POS_DATASET_PATH="${DATASET_FOLDER}/${DATASET_NAME}/positive"
@@ -51,8 +51,6 @@ MFA_FOLDER="./montreal-forced-aligner"
 pushd ${MFA_FOLDER}
 # yes n for "There were words not found in the dictionary. Would you like to abort to fix them? (Y/N)"
 # if process fails, check ~/Documents/MFA/audio/train/mfcc/log/make_mfcc.0.log
-# it's often due to missing openblas or fortran packages
-# if this is the case, simply install them using apt
 time yes n | ./bin/mfa_align --verbose --clean --num_jobs 12 "../${POS_DATASET_PATH}/audio" librispeech-lexicon.txt pretrained_models/english.zip "../${POS_DATASET_ALIGNMENT}"
 popd
 

--- a/howl/dataset/README.md
+++ b/howl/dataset/README.md
@@ -84,6 +84,11 @@ intervals [4]:
 ```bash
 mfa_align datasets/fire/positive/audio eng.dict pretrained_models/english.zip datasets/fire/positive/alignment
 ```
+If this process is raising an error, you can take a look at `~/Documents/MFA/audio/train/mfcc/log/make_mfcc.0.log`
+
+It's often due to missing openblas or fortran packages
+
+If openblas is installed and the error message is coming from missing `raw_mfcc.0.scp` file, you can take a look at [this issue](https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/issues/149#issuecomment-621165857)
 
 6. Attach MFA alignments to the positive datasets:
 

--- a/howl/dataset/raw_audio_dataset_generator.py
+++ b/howl/dataset/raw_audio_dataset_generator.py
@@ -39,7 +39,7 @@ class RawAudioDatasetGenerator:
             self.logger = logging_utils.setup_logger(self.__class__.__name__)
 
         self.dataset_loader_type = dataset_loader_type
-        self.dataset_loader = get_dataset_loader(dataset_loader_type, Path(input_dataset_path), self.logger)
+        self.dataset_loader = get_dataset_loader(dataset_loader_type, Path(input_dataset_path))
         self.inference_ctx = InferenceContext(vocab=SETTINGS.training.vocab, token_type=SETTINGS.training.token_type)
 
         ds_kwargs = dict(sample_rate=SETTINGS.audio.sample_rate, mono=SETTINGS.audio.use_mono)
@@ -99,4 +99,4 @@ class RawAudioDatasetGenerator:
             if print_statistics:
                 dataset.print_stats(self.logger, word_searcher=word_searcher, compute_length=True)
             self.logger.info(f"Generating {dataset.dataset_split.value} dataset")
-            AudioDatasetWriter(dataset, logger=self.logger).write(dataset_path)
+            AudioDatasetWriter(dataset).write(dataset_path)

--- a/howl/dataset_loader/common_voice_dataset_loader.py
+++ b/howl/dataset_loader/common_voice_dataset_loader.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 
 import pandas as pd
@@ -23,14 +22,13 @@ class CommonVoiceDatasetLoader(AudioDatasetLoader):
         DatasetSplit.TEST: "test.tsv",
     }
 
-    def __init__(self, dataset_path: Path, logger: logging.Logger = None):
+    def __init__(self, dataset_path: Path):
         """initialize CommonVoiceDatasetLoader for the given path
 
         Args:
             dataset_path: location of the dataset
-            logger: logger
         """
-        super().__init__(self.NAME, dataset_path=dataset_path, logger=logger)
+        super().__init__(self.NAME, dataset_path=dataset_path)
 
     def _load_dataset(self, dataset_split: DatasetSplit, **dataset_kwargs) -> AudioDataset:
         """Load dataset of given dataset_split

--- a/howl/dataset_loader/dataset_loader.py
+++ b/howl/dataset_loader/dataset_loader.py
@@ -1,15 +1,14 @@
-import logging
 from pathlib import Path
 from typing import Tuple
 
 from howl.data.dataset.dataset import AudioDataset, DatasetSplit
-from howl.utils import logging_utils
+from howl.utils.logger import Logger
 
 
 class AudioDatasetLoader:
     """Load and create dataset instances from local files."""
 
-    def __init__(self, name: str, dataset_path: Path, logger: logging.Logger = None):
+    def __init__(self, name: str, dataset_path: Path):
         """Initialize AudioDatasetLoader for the given path.
 
         Args:
@@ -22,10 +21,6 @@ class AudioDatasetLoader:
         if not self.dataset_path.exists():
             raise FileNotFoundError(f"Dataset path for {self.name} is invalid: {self.dataset_path}")
 
-        self.logger = logger
-        if self.logger is None:
-            self.logger = logging_utils.setup_logger(f"DatasetLoader-{self.name}")
-
     def _load_dataset(self, dataset_split: DatasetSplit, **dataset_kwargs) -> AudioDataset:
         """Load dataset of given dataset_split.
 
@@ -37,7 +32,7 @@ class AudioDatasetLoader:
             dataset for the given dataset_split
         """
         # pylint: disable=unused-argument
-        self.logger.info(f"Loading {dataset_split.value} split")
+        Logger.info(f"Loading {dataset_split.value} split")
         raise NotImplementedError("Not yet implemented for {}".format(self.__class__.__name__))
 
     def load_splits(self, **dataset_kwargs) -> Tuple[AudioDataset, AudioDataset, AudioDataset]:

--- a/howl/dataset_loader/dataset_loader_factory.py
+++ b/howl/dataset_loader/dataset_loader_factory.py
@@ -1,7 +1,7 @@
-import logging
 from enum import Enum, unique
 from pathlib import Path
 
+from howl.dataset_loader.aligned_audio_dataset_loader import AlignedAudioDatasetLoader
 from howl.dataset_loader.common_voice_dataset_loader import CommonVoiceDatasetLoader
 from howl.dataset_loader.dataset_loader import AudioDatasetLoader
 from howl.dataset_loader.raw_audio_dataset_loader import RawAudioDatasetLoader
@@ -13,25 +13,23 @@ class DatasetLoaderType(str, Enum):
 
     COMMON_VOICE_DATASET_LOADER = CommonVoiceDatasetLoader.NAME
     RAW_AUDIO_DATASET_LOADER = RawAudioDatasetLoader.NAME
+    ALIGNED_AUDIO_DATASET_LOADER = AlignedAudioDatasetLoader.NAME
 
 
-def get_dataset_loader(
-    dataset_loader_type: DatasetLoaderType, dataset_path: Path, logger: logging.Logger = None,
-) -> AudioDatasetLoader:
+def get_dataset_loader(dataset_loader_type: DatasetLoaderType, dataset_path: Path) -> AudioDatasetLoader:
     """Get dataset loader of the given type
 
     Args:
         dataset_loader_type: type of the dataset loader
         dataset_path: location of the dataset
-        logger: logger
 
     Returns:
         Dataset loader of the given type
     """
     if dataset_loader_type == DatasetLoaderType.COMMON_VOICE_DATASET_LOADER:
-        dataset_loader = CommonVoiceDatasetLoader(dataset_path, logger)
+        dataset_loader = CommonVoiceDatasetLoader(dataset_path)
     elif dataset_loader_type == DatasetLoaderType.RAW_AUDIO_DATASET_LOADER:
-        dataset_loader = RawAudioDatasetLoader(dataset_path, logger)
+        dataset_loader = RawAudioDatasetLoader(dataset_path)
     else:
         raise RuntimeError(f"Given dataset loader type is invalid: {dataset_loader_type}")
 

--- a/howl/dataset_loader/dataset_loader_factory.py
+++ b/howl/dataset_loader/dataset_loader_factory.py
@@ -1,7 +1,6 @@
 from enum import Enum, unique
 from pathlib import Path
 
-from howl.dataset_loader.aligned_audio_dataset_loader import AlignedAudioDatasetLoader
 from howl.dataset_loader.common_voice_dataset_loader import CommonVoiceDatasetLoader
 from howl.dataset_loader.dataset_loader import AudioDatasetLoader
 from howl.dataset_loader.raw_audio_dataset_loader import RawAudioDatasetLoader
@@ -13,7 +12,6 @@ class DatasetLoaderType(str, Enum):
 
     COMMON_VOICE_DATASET_LOADER = CommonVoiceDatasetLoader.NAME
     RAW_AUDIO_DATASET_LOADER = RawAudioDatasetLoader.NAME
-    ALIGNED_AUDIO_DATASET_LOADER = AlignedAudioDatasetLoader.NAME
 
 
 def get_dataset_loader(dataset_loader_type: DatasetLoaderType, dataset_path: Path) -> AudioDatasetLoader:

--- a/howl/dataset_loader/raw_audio_dataset_loader.py
+++ b/howl/dataset_loader/raw_audio_dataset_loader.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from pathlib import Path
 
 from tqdm import tqdm
@@ -16,14 +15,13 @@ class RawAudioDatasetLoader(AudioDatasetLoader):
     # unique name which this dataset loader will be referred to
     NAME = "raw"
 
-    def __init__(self, dataset_path: Path, logger: logging.Logger = None):
+    def __init__(self, dataset_path: Path):
         """Initialize RawAudioDatasetLoader for the given path.
 
         Args:
             dataset_path: location of the dataset
-            logger = logger
         """
-        super().__init__(self.NAME, dataset_path=dataset_path, logger=logger)
+        super().__init__(self.NAME, dataset_path=dataset_path)
 
     def _load_dataset(self, dataset_split: DatasetSplit, **dataset_kwargs) -> AudioDataset:
         """Load raw audio dataset of given dataset_split

--- a/howl/utils/logger.py
+++ b/howl/utils/logger.py
@@ -1,10 +1,95 @@
+import logging
 import os
+import sys
+from logging.handlers import RotatingFileHandler
 
 import coloredlogs
 
-__all__ = []
+
+def setup_logger(name, level=logging.INFO, use_stdout=True, log_path=None):
+    """Setup of logger
+
+    Args:
+        name: Logger name
+        level: Verbosity level
+        use_stdout: Whether to add stdout as a handler
+        log_path: Log file path
+
+    Returns:
+        A logger
+    """
+
+    log_format = "%(asctime)s %(levelname)s %(funcName)s(%(lineno)d) %(message)s"
+    formatter = logging.Formatter(log_format)
+
+    coloredlogs.install(level=level, fmt=log_format)
+    logger = logging.getLogger(name)
+
+    # Remove existing handlers if there are any
+    if logger.hasHandlers():
+        logging.warning(f"Removing existing handlers from {name} logger")
+        for handler in logger.handlers:
+            logger.removeHandler(handler)
+
+    if log_path is not None:
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        # Limit log to 5MB
+        handler = RotatingFileHandler(
+            log_path, mode="a", maxBytes=5 * 1024 * 1024, backupCount=2, encoding=None, delay=False,
+        )
+        handler.setFormatter(formatter)
+        handler.setLevel(level)
+        logger.addHandler(handler)
+
+    if use_stdout:
+        # Don't propagate messages to root (stderr) logger
+        logger.propagate = False
+
+        # Show output in stdout
+        std_out_handler = logging.StreamHandler(sys.stdout)
+        std_out_handler.setFormatter(formatter)
+        std_out_handler.setLevel(level)
+        logger.addHandler(std_out_handler)
+
+    logger.info(f"Set up logger ({name}), output path: {log_path}")
+    return logger
 
 
-coloredlogs.install(
-    level=os.environ.get("HOWL_LOG_LEVEL", "INFO"), fmt="%(asctime)s [%(levelname)s] %(module)s: %(message)s"
-)
+class Logger:
+    """logging.Logger instance cannot be pickled. This class will manage a single logger across the system"""
+
+    LOGGER = None
+    NAME = "Howl"
+
+    def __init__(self):
+        raise NotImplementedError("All Logger methods are static. Do not instantiate")
+
+    @staticmethod
+    def init_logger_if_missing():
+        """Create logger if missing"""
+        if Logger.LOGGER is None:
+            Logger.LOGGER = setup_logger(Logger.NAME)
+
+    @staticmethod
+    def info(msg: str):
+        """log for INFO level"""
+        Logger.init_logger_if_missing()
+        Logger.LOGGER.info(msg)
+
+    @staticmethod
+    def debug(msg: str):
+        """log for DEBUG level"""
+        Logger.init_logger_if_missing()
+        Logger.LOGGER.debug(msg)
+
+    @staticmethod
+    def warning(msg: str):
+        """log for WARNING level"""
+        Logger.init_logger_if_missing()
+        Logger.LOGGER.warning(msg)
+
+    @staticmethod
+    def error(msg: str):
+        """log for ERROR level"""
+        Logger.init_logger_if_missing()
+        Logger.LOGGER.error(msg)

--- a/howl/utils/str_utils.py
+++ b/howl/utils/str_utils.py
@@ -1,0 +1,21 @@
+from distutils.util import strtobool as distutils_strtobool
+
+
+def strtobool(bool_str: str):
+    """Convert a string representation of truth to True or False.
+    Wraps disutils.strtobool, please see documentation here: https://docs.python.org/3/distutils/apiref.html
+    Quote at time of writing:
+    True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0.
+    Raises ValueError if bool_str is anything else.
+
+    Note: default value for boolean argument is always false
+          that we had some difficulties in controlling the flag from our code
+          Therefore, we use string-typed argument and convert the value to boolean using strtobool
+
+    Args:
+        bool_str: True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0.
+
+    Returns:
+        bool - Raises ValueError if bool_str is not an accepted string
+    """
+    return bool(distutils_strtobool(bool_str.lower()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pydantic>=1.7.3
 pytest==6.2.3
 soundfile==0.10.3.post1
 tensorboard
-torch>=1.5.0
+torch==1.10.1
 torchaudio>=0.5.0
 torchvision>=0.6.0
 tqdm

--- a/requirements_training.txt
+++ b/requirements_training.txt
@@ -1,6 +1,4 @@
 openpyxl
-pocketsphinx==0.1.15
 praat-textgrids==1.3.1
 pre-commit
-pytest
 webrtcvad==2.0.10

--- a/training/run/deprecated/create_raw_dataset.py
+++ b/training/run/deprecated/create_raw_dataset.py
@@ -84,7 +84,7 @@ def main():
     logger = logging_utils.setup_logger(os.path.basename(__file__))
 
     dataset_loader_type = DatasetLoaderType(args.dataset_loader_type)
-    dataset_loader = get_dataset_loader(dataset_loader_type, Path(args.input_audio_dataset_path), logger)
+    dataset_loader = get_dataset_loader(dataset_loader_type, Path(args.input_audio_dataset_path))
     ds_kwargs = dict(sample_rate=SETTINGS.audio.sample_rate, mono=SETTINGS.audio.use_mono)
     train_ds, dev_ds, test_ds = dataset_loader.load_splits(**ds_kwargs)
 


### PR DESCRIPTION
`logging.Logger` instance cannot be pickled causing some issues when parallelizing data generation.
This new Logger class will manage a single logger across the system.

* overwrite for `generate_raw_audio_dataset.py`
* upgrading torch version `torch==1.10.1`
